### PR TITLE
Add Streamlit stock analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,96 @@
-# ntrp
-R. Natera Porfolio
+# Stock Market Analytics Dashboard
+
+An easy-to-follow Streamlit project designed for new developers who want to explore
+real-time market data, backtesting, and simple portfolio tracking in one place.
+
+## Features
+
+- **Live market data** – pull equities and futures quotes from Yahoo Finance with
+  adjustable history and intervals.
+- **Interactive charts** – Plotly candlesticks with optional moving averages, RSI,
+  and MACD overlays.
+- **Strategy backtesting** – simulate a moving-average crossover strategy and
+  compare it to a buy-and-hold benchmark.
+- **Portfolio tracker** – log trades into a lightweight SQLite database and view
+  mark-to-market P&L.
+- **Export tools** – download prices, backtest results, and trade history as CSV
+  or Excel files for further analysis.
+
+## Project structure
+
+```
+.
+├── app.py                     # Streamlit application entry point
+├── requirements.txt           # Python dependencies
+└── stock_dashboard
+    ├── __init__.py
+    ├── backtesting.py         # Strategy simulator
+    ├── data.py                # Market data helpers
+    ├── indicators.py          # Technical indicator calculations
+    └── portfolio.py           # SQLite-backed trade ledger
+```
+
+## Getting started
+
+1. Create and activate a virtual environment (optional but recommended):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Launch the Streamlit dashboard:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+4. Streamlit will open a new browser tab. Use the sidebar to select a ticker, change the
+   date range, and toggle indicators. The main page updates automatically.
+
+## Working with the dashboard
+
+### Market overview
+
+- Choose a ticker (e.g., `AAPL`, `NQ=F`) and pick a history period plus interval.
+- The headline metrics show the latest closing price, volume, and daily change.
+- Download the displayed price data as CSV or Excel with a single click.
+
+### Technical indicators
+
+- Toggle simple or exponential moving averages to overlay on the candlestick chart.
+- Enable the RSI and MACD panels to judge momentum and trend strength.
+- Indicator look-back periods can be customised from the sidebar.
+
+### Backtesting a moving-average crossover
+
+- In the **Strategy Backtesting** section, choose fast/slow MA windows and click
+  **Run backtest**.
+- The dashboard compares the crossover strategy against buy-and-hold performance,
+  highlighting total return, drawdown, Sharpe ratio, and win rate.
+- Download the backtest equity curve and signal table as CSV or Excel for more
+detailed analysis.
+
+### Portfolio tracker
+
+- Log trades using the **Add a trade** form. The tracker is geared toward long-only
+  positions and stores data in `stock_dashboard/data/portfolio.db`.
+- View the running trade ledger and portfolio summary, including realised and
+  unrealised P&L. Trades can be exported just like the price data.
+- Use the **Danger zone** expander to clear all stored trades if you want to start over.
+
+## Notes & tips
+
+- Yahoo Finance limits request rates; if data fails to load, wait a moment and try again.
+- Futures symbols typically end with `=F` (e.g., `ES=F` for S&P 500 E-mini futures).
+- The project is intentionally simple so you can extend it—try adding new indicators,
+  risk metrics, or alternate data sources.
+- For production use you should secure the SQLite database and add authentication.
+
+Enjoy experimenting and building your market intuition!

--- a/app.py
+++ b/app.py
@@ -1,0 +1,434 @@
+"""Streamlit entry point for the Stock Market Analytics Dashboard."""
+from __future__ import annotations
+
+import io
+from datetime import date
+from typing import Dict
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from stock_dashboard.backtesting import BacktestResult, ma_crossover_backtest
+from stock_dashboard.data import fetch_price_data
+from stock_dashboard.indicators import calculate_ema, calculate_macd, calculate_rsi, calculate_sma
+from stock_dashboard.portfolio import PortfolioManager, Trade
+
+
+st.set_page_config(
+    page_title="Stock Market Analytics Dashboard",
+    page_icon="📈",
+    layout="wide",
+)
+
+
+# ---------------------------------------------------------------------------
+# Streamlit cache helpers
+# ---------------------------------------------------------------------------
+@st.cache_data(ttl=300)
+def load_price_data(symbol: str, period: str, interval: str) -> pd.DataFrame:
+    return fetch_price_data(symbol, period=period, interval=interval)
+
+
+
+def dataframe_to_csv_bytes(df: pd.DataFrame) -> bytes:
+    return df.to_csv().encode("utf-8")
+
+
+def dataframe_to_excel_bytes(df: pd.DataFrame, sheet_name: str = "data") -> bytes:
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+        df.to_excel(writer, sheet_name=sheet_name)
+    return buffer.getvalue()
+
+
+def prepare_indicator_data(
+    price_data: pd.DataFrame, sma_window: int, ema_window: int, rsi_period: int
+) -> pd.DataFrame:
+    data = price_data.copy()
+    data[f"SMA_{sma_window}"] = calculate_sma(data["Close"], window=sma_window)
+    data[f"EMA_{ema_window}"] = calculate_ema(data["Close"], span=ema_window)
+    data["RSI"] = calculate_rsi(data["Close"], period=rsi_period)
+    macd_line, signal_line, hist = calculate_macd(data["Close"])
+    data["MACD"] = macd_line
+    data["MACD_Signal"] = signal_line
+    data["MACD_Hist"] = hist
+    data["Daily Change %"] = data["Close"].pct_change() * 100
+    return data
+
+
+def build_price_chart(
+    data: pd.DataFrame,
+    ticker: str,
+    show_sma: bool,
+    sma_window: int,
+    show_ema: bool,
+    ema_window: int,
+) -> go.Figure:
+    fig = go.Figure()
+    fig.add_trace(
+        go.Candlestick(
+            x=data.index,
+            open=data["Open"],
+            high=data["High"],
+            low=data["Low"],
+            close=data["Close"],
+            name=f"{ticker} price",
+        )
+    )
+
+    if show_sma:
+        fig.add_trace(
+            go.Scatter(
+                x=data.index,
+                y=data[f"SMA_{sma_window}"],
+                mode="lines",
+                name=f"SMA {sma_window}",
+            )
+        )
+
+    if show_ema:
+        fig.add_trace(
+            go.Scatter(
+                x=data.index,
+                y=data[f"EMA_{ema_window}"],
+                mode="lines",
+                name=f"EMA {ema_window}",
+            )
+        )
+
+    fig.update_layout(
+        title=f"{ticker} Candlestick Chart",
+        yaxis_title="Price",
+        xaxis_title="Date",
+        template="plotly_white",
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+        height=600,
+    )
+    fig.update_xaxes(showgrid=True)
+    fig.update_yaxes(showgrid=True)
+    return fig
+
+
+def build_rsi_chart(data: pd.DataFrame) -> go.Figure:
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=data.index, y=data["RSI"], name="RSI", mode="lines"))
+    fig.add_hline(y=70, line_dash="dash", line_color="red")
+    fig.add_hline(y=30, line_dash="dash", line_color="green")
+    fig.update_layout(
+        title="Relative Strength Index",
+        yaxis_title="RSI",
+        xaxis_title="Date",
+        template="plotly_white",
+        height=300,
+    )
+    return fig
+
+
+def build_macd_chart(data: pd.DataFrame) -> go.Figure:
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=data.index, y=data["MACD"], name="MACD", mode="lines"))
+    fig.add_trace(
+        go.Scatter(x=data.index, y=data["MACD_Signal"], name="Signal", mode="lines")
+    )
+    fig.add_trace(
+        go.Bar(x=data.index, y=data["MACD_Hist"], name="Histogram", opacity=0.4)
+    )
+    fig.update_layout(
+        title="MACD",
+        xaxis_title="Date",
+        yaxis_title="Value",
+        template="plotly_white",
+        height=300,
+        barmode="group",
+    )
+    return fig
+
+
+def render_market_overview(data: pd.DataFrame, ticker: str) -> None:
+    latest_close = float(data["Close"].iloc[-1])
+    previous_close = float(data["Close"].iloc[-2]) if len(data) > 1 else latest_close
+    percent_change = (
+        ((latest_close - previous_close) / previous_close) * 100 if previous_close else 0.0
+    )
+
+    volume_value = data["Volume"].iloc[-1] if "Volume" in data.columns else None
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Last close", f"${latest_close:,.2f}", f"{percent_change:+.2f}%")
+    if volume_value is not None:
+        col2.metric("Volume", f"{volume_value:,.0f}")
+    if "Daily Change %" in data.columns and not pd.isna(data["Daily Change %"].iloc[-1]):
+        col3.metric("Daily change", f"{data['Daily Change %'].iloc[-1]:+.2f}%")
+
+
+def render_backtest_section(price_data: pd.DataFrame, ticker: str) -> None:
+    st.subheader("Strategy Backtesting")
+    st.markdown(
+        "Test a simple moving average crossover strategy. A position is opened when the"
+        " fast moving average crosses above the slow moving average and closed when it"
+        " falls back below."
+    )
+
+    with st.form("backtest_form"):
+        col1, col2, col3 = st.columns(3)
+        fast_window = col1.number_input("Fast MA window", min_value=5, max_value=200, value=20)
+        slow_window = col2.number_input("Slow MA window", min_value=10, max_value=300, value=50)
+        initial_cash = col3.number_input(
+            "Starting capital (for context)", min_value=1000.0, value=10000.0, step=500.0
+        )
+        run_backtest = st.form_submit_button("Run backtest")
+
+    if not run_backtest:
+        return
+
+    try:
+        result: BacktestResult = ma_crossover_backtest(
+            price_data, fast_window=int(fast_window), slow_window=int(slow_window)
+        )
+    except ValueError as exc:
+        st.error(str(exc))
+        return
+
+    st.success("Backtest completed.")
+
+    stats = result.statistics
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Strategy return", f"{stats['strategy_return_pct']:.2f}%")
+    col2.metric("Market return", f"{stats['market_return_pct']:.2f}%")
+    col3.metric("Sharpe ratio", f"{stats['sharpe_ratio']:.2f}")
+
+    col4, col5, col6 = st.columns(3)
+    col4.metric("Total trades", f"{stats['total_trades']:.0f}")
+    col5.metric("Max drawdown", f"{stats['max_drawdown_pct']:.2f}%")
+    col6.metric("Win rate", f"{stats['win_rate'] * 100:.2f}%")
+
+    equity = result.equity_curve
+    ending_value_strategy = initial_cash * float(equity["Cumulative Strategy"].iloc[-1])
+    ending_value_market = initial_cash * float(equity["Cumulative Market"].iloc[-1])
+
+    col7, col8 = st.columns(2)
+    col7.metric("Strategy ending value", f'${ending_value_strategy:,.2f}')
+    col8.metric("Buy & Hold ending value", f'${ending_value_market:,.2f}')
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=equity.index,
+            y=equity["Cumulative Market"],
+            name="Buy & Hold",
+            mode="lines",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=equity.index,
+            y=equity["Cumulative Strategy"],
+            name="MA Crossover",
+            mode="lines",
+        )
+    )
+    fig.update_layout(
+        title=f"{ticker} – Backtest Equity Curve",
+        xaxis_title="Date",
+        yaxis_title="Growth of $1",
+        template="plotly_white",
+        height=450,
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.markdown("### Trade signals and returns")
+    display_columns = [
+        "Close",
+        "FastMA",
+        "SlowMA",
+        "Signal",
+        "Position",
+        "Market Return",
+        "Strategy Return",
+    ]
+    st.dataframe(equity[display_columns].tail(20))
+
+    st.download_button(
+        label="Download backtest (CSV)",
+        data=dataframe_to_csv_bytes(equity),
+        file_name=f"{ticker}_backtest.csv",
+        mime="text/csv",
+    )
+    st.download_button(
+        label="Download backtest (Excel)",
+        data=dataframe_to_excel_bytes(equity, sheet_name="backtest"),
+        file_name=f"{ticker}_backtest.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+
+def render_portfolio_section(ticker: str, latest_close: float | None) -> None:
+    st.subheader("Portfolio Tracker")
+    st.markdown(
+        "Log trades to keep track of position sizes and P&L. The tracker assumes"
+        " long positions by default."
+    )
+
+    manager = PortfolioManager()
+
+    with st.expander("Add a trade", expanded=True):
+        with st.form("trade_form"):
+            col1, col2 = st.columns(2)
+            symbol = col1.text_input("Ticker", value=ticker).upper()
+            trade_date = col2.date_input("Trade date", value=date.today())
+
+            col3, col4, col5 = st.columns(3)
+            quantity = col3.number_input("Quantity", min_value=0.0, value=1.0, step=1.0)
+            price = col4.number_input("Price", min_value=0.0, value=latest_close or 0.0, step=0.5)
+            side = col5.selectbox("Side", options=["BUY", "SELL"], index=0)
+            fees = st.number_input("Fees (optional)", min_value=0.0, value=0.0, step=0.5)
+
+            submitted = st.form_submit_button("Save trade")
+
+        if submitted:
+            try:
+                trade = Trade(
+                    symbol=symbol,
+                    trade_date=trade_date,
+                    quantity=float(quantity),
+                    price=float(price),
+                    side=side,
+                    fees=float(fees),
+                )
+                manager.add_trade(trade)
+                st.success("Trade saved. Scroll down to see the updated ledger.")
+            except ValueError as exc:
+                st.error(str(exc))
+
+    with st.expander("Danger zone"):
+        if st.button("Clear all trades"):
+            manager.clear_trades()
+            st.warning("Trade history cleared.")
+
+    trades = manager.get_trades()
+    if trades.empty:
+        st.info("No trades recorded yet. Use the form above to add your first trade.")
+        return
+
+    st.markdown("### Trade history")
+    st.dataframe(trades)
+    st.download_button(
+        label="Download trades (CSV)",
+        data=dataframe_to_csv_bytes(trades),
+        file_name="trade_history.csv",
+        mime="text/csv",
+    )
+    st.download_button(
+        label="Download trades (Excel)",
+        data=dataframe_to_excel_bytes(trades, sheet_name="trades"),
+        file_name="trade_history.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+    latest_prices: Dict[str, float | None] = {}
+    if latest_close is not None and ticker:
+        latest_prices[ticker.upper()] = latest_close
+
+    summary = manager.get_portfolio_summary(latest_prices=latest_prices)
+    st.markdown("### Positions overview")
+    st.dataframe(summary)
+
+    if not summary.empty:
+        total_value = summary["market_value"].replace({pd.NA: 0}).fillna(0).sum()
+        total_unrealized = summary["unrealized_pl"].replace({pd.NA: 0}).fillna(0).sum()
+        total_realized = summary["realized_pl"].replace({pd.NA: 0}).fillna(0).sum()
+
+        col1, col2, col3 = st.columns(3)
+        col1.metric("Portfolio market value", f"${total_value:,.2f}")
+        col2.metric("Unrealized P&L", f"${total_unrealized:,.2f}")
+        col3.metric("Realized P&L", f"${total_realized:,.2f}")
+
+
+def main() -> None:
+    st.title("Stock Market Analytics Dashboard — Real-Time Trading Insights")
+    st.write(
+        "Monitor live markets, run quick strategy experiments, and keep a simple log of"
+        " your portfolio without leaving this page. Perfect for new traders exploring"
+        " quantitative analysis."
+    )
+
+    with st.sidebar:
+        st.header("Market data")
+        ticker = st.text_input("Ticker symbol", value="AAPL").upper()
+        period = st.selectbox(
+            "History", options=["5d", "1mo", "3mo", "6mo", "1y", "2y", "5y"], index=3
+        )
+        interval = st.selectbox(
+            "Interval",
+            options=["15m", "30m", "60m", "1d", "1wk"],
+            index=3,
+        )
+        st.caption("Prices are retrieved from Yahoo Finance via the yfinance package.")
+
+        with st.expander("Indicator settings", expanded=True):
+            show_sma = st.checkbox("Show SMA", value=True)
+            sma_window = st.slider("SMA window", min_value=5, max_value=200, value=20)
+            show_ema = st.checkbox("Show EMA", value=True)
+            ema_window = st.slider("EMA window", min_value=5, max_value=200, value=50)
+            show_rsi = st.checkbox("Show RSI", value=True)
+            show_macd = st.checkbox("Show MACD", value=True)
+            rsi_period = st.slider("RSI period", min_value=5, max_value=50, value=14)
+
+    if not ticker:
+        st.info("Enter a ticker symbol to begin.")
+        return
+
+    try:
+        price_data = load_price_data(ticker, period, interval)
+    except ValueError as exc:
+        st.error(str(exc))
+        return
+    except ConnectionError as exc:
+        st.error(str(exc))
+        return
+
+    indicator_data = prepare_indicator_data(price_data, sma_window, ema_window, rsi_period)
+    latest_close = float(indicator_data["Close"].iloc[-1]) if not indicator_data.empty else None
+
+    render_market_overview(indicator_data, ticker)
+
+    price_chart = build_price_chart(
+        indicator_data,
+        ticker=ticker,
+        show_sma=show_sma,
+        sma_window=sma_window,
+        show_ema=show_ema,
+        ema_window=ema_window,
+    )
+    st.plotly_chart(price_chart, use_container_width=True)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.download_button(
+            label="Download prices (CSV)",
+            data=dataframe_to_csv_bytes(indicator_data),
+            file_name=f"{ticker}_prices.csv",
+            mime="text/csv",
+        )
+    with col2:
+        st.download_button(
+            label="Download prices (Excel)",
+            data=dataframe_to_excel_bytes(indicator_data, sheet_name="prices"),
+            file_name=f"{ticker}_prices.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+
+    if show_rsi:
+        st.plotly_chart(build_rsi_chart(indicator_data), use_container_width=True)
+    if show_macd:
+        st.plotly_chart(build_macd_chart(indicator_data), use_container_width=True)
+
+    render_backtest_section(price_data, ticker)
+
+    st.markdown("---")
+    render_portfolio_section(ticker, latest_close)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit>=1.30
+pandas>=1.5
+numpy>=1.23
+plotly>=5.18
+yfinance>=0.2
+XlsxWriter>=3.0

--- a/stock_dashboard/__init__.py
+++ b/stock_dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for the Stock Market Analytics dashboard."""

--- a/stock_dashboard/backtesting.py
+++ b/stock_dashboard/backtesting.py
@@ -1,0 +1,85 @@
+"""Simple backtesting utilities used by the Streamlit dashboard."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+
+from .indicators import calculate_sma
+
+
+@dataclass
+class BacktestResult:
+    """Container for the strategy equity curve and summary statistics."""
+
+    equity_curve: pd.DataFrame
+    statistics: Dict[str, float]
+
+
+def _max_drawdown(series: pd.Series) -> float:
+    """Return the maximum drawdown of a cumulative returns series."""
+    if series.empty:
+        return 0.0
+    cumulative_max = series.cummax()
+    drawdown = series / cumulative_max - 1
+    return float(drawdown.min())
+
+
+def ma_crossover_backtest(
+    price_data: pd.DataFrame,
+    fast_window: int = 20,
+    slow_window: int = 50,
+) -> BacktestResult:
+    """Run a long-only moving average crossover backtest.
+
+    Parameters
+    ----------
+    price_data:
+        DataFrame that contains at least the ``Close`` column.
+    fast_window / slow_window:
+        Moving average look-back periods. ``fast_window`` must be shorter
+        than ``slow_window``.
+    """
+    if "Close" not in price_data.columns:
+        raise ValueError("price_data must contain a 'Close' column")
+    if fast_window >= slow_window:
+        raise ValueError("fast_window should be smaller than slow_window")
+
+    frame = price_data[["Close"]].copy()
+    frame["FastMA"] = calculate_sma(frame["Close"], window=fast_window)
+    frame["SlowMA"] = calculate_sma(frame["Close"], window=slow_window)
+    frame.dropna(inplace=True)
+
+    if frame.empty:
+        raise ValueError("Not enough data to compute the moving averages.")
+
+    frame["Signal"] = 0
+    frame.loc[frame["FastMA"] > frame["SlowMA"], "Signal"] = 1
+    frame["Position"] = frame["Signal"].shift(1).fillna(0)
+
+    frame["Market Return"] = frame["Close"].pct_change().fillna(0)
+    frame["Strategy Return"] = frame["Market Return"] * frame["Position"]
+
+    frame["Cumulative Market"] = (1 + frame["Market Return"]).cumprod()
+    frame["Cumulative Strategy"] = (1 + frame["Strategy Return"]).cumprod()
+
+    trades = frame["Position"].diff().abs().sum()
+    winning_periods = (frame.loc[frame["Position"] != 0, "Strategy Return"] > 0).sum()
+    active_periods = (frame["Position"] != 0).sum()
+    win_rate = (winning_periods / active_periods) if active_periods else 0.0
+
+    avg_return = frame["Strategy Return"].mean()
+    volatility = frame["Strategy Return"].std()
+    sharpe = (avg_return / volatility * (252 ** 0.5)) if volatility else 0.0
+
+    statistics = {
+        "total_trades": float(trades),
+        "strategy_return_pct": float((frame["Cumulative Strategy"].iloc[-1] - 1) * 100),
+        "market_return_pct": float((frame["Cumulative Market"].iloc[-1] - 1) * 100),
+        "max_drawdown_pct": float(_max_drawdown(frame["Cumulative Strategy"]) * 100),
+        "win_rate": float(win_rate),
+        "sharpe_ratio": float(sharpe),
+    }
+
+    return BacktestResult(equity_curve=frame, statistics=statistics)

--- a/stock_dashboard/data.py
+++ b/stock_dashboard/data.py
@@ -1,0 +1,103 @@
+"""Utility functions for retrieving market data using yfinance."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class PriceRequest:
+    """Container describing how much history should be fetched for a ticker."""
+
+    symbol: str
+    period: str = "6mo"
+    interval: str = "1d"
+
+    def normalized_symbol(self) -> str:
+        """Return the symbol upper-cased and stripped of whitespace."""
+        return self.symbol.strip().upper()
+
+
+def _clean_index(frame: pd.DataFrame) -> pd.DataFrame:
+    """Ensure the dataframe index is timezone naive for plotting purposes."""
+    if isinstance(frame.index, pd.DatetimeIndex):
+        frame.index = frame.index.tz_localize(None)
+    return frame
+
+
+def fetch_price_data(symbol: str, period: str = "6mo", interval: str = "1d") -> pd.DataFrame:
+    """Retrieve historical price data for a ticker symbol.
+
+    Parameters
+    ----------
+    symbol:
+        Ticker symbol recognised by Yahoo Finance (e.g. ``"AAPL"``).
+    period:
+        The look-back period such as ``"1mo"``, ``"6mo"``, or ``"1y"``.
+    interval:
+        Resolution of the data, e.g. ``"1d"`` for daily or ``"1h"`` for hourly bars.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Historical OHLCV data indexed by timestamp.
+
+    Raises
+    ------
+    ValueError
+        If ``symbol`` is blank or no data could be downloaded.
+    ConnectionError
+        If yfinance raises an exception while requesting data.
+    """
+    cleaned_symbol = symbol.strip().upper()
+    if not cleaned_symbol:
+        raise ValueError("A ticker symbol is required to download price data.")
+
+    request = PriceRequest(cleaned_symbol, period, interval)
+
+    try:
+        frame = yf.download(
+            request.normalized_symbol(),
+            period=request.period,
+            interval=request.interval,
+            auto_adjust=False,
+            progress=False,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard for API errors
+        raise ConnectionError(f"Could not download data for {cleaned_symbol}: {exc}") from exc
+
+    if frame.empty:
+        raise ValueError(
+            "Yahoo Finance returned no data. Double check the ticker symbol and interval."
+        )
+
+    return _clean_index(frame)
+
+
+def fetch_latest_price(symbol: str) -> Optional[float]:
+    """Return the latest closing price for ``symbol`` if it can be determined."""
+    cleaned_symbol = symbol.strip().upper()
+    if not cleaned_symbol:
+        return None
+
+    try:
+        latest = yf.download(
+            cleaned_symbol,
+            period="5d",
+            interval="1d",
+            progress=False,
+        )
+    except Exception:  # pragma: no cover - yfinance network failures
+        return None
+
+    if latest.empty:
+        return None
+
+    latest = _clean_index(latest)
+    close_series = latest.get("Close")
+    if close_series is None or close_series.empty:
+        return None
+    return float(close_series.iloc[-1])

--- a/stock_dashboard/data/.gitignore
+++ b/stock_dashboard/data/.gitignore
@@ -1,0 +1,1 @@
+portfolio.db

--- a/stock_dashboard/indicators.py
+++ b/stock_dashboard/indicators.py
@@ -1,0 +1,46 @@
+"""Collection of helper functions for computing popular technical indicators."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def calculate_sma(close: pd.Series, window: int = 20) -> pd.Series:
+    """Simple moving average of ``close`` prices."""
+    return close.rolling(window=window, min_periods=window).mean()
+
+
+def calculate_ema(close: pd.Series, span: int = 20) -> pd.Series:
+    """Exponential moving average of ``close`` prices."""
+    return close.ewm(span=span, adjust=False).mean()
+
+
+def calculate_rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    """Relative Strength Index (RSI).
+
+    The implementation follows the classic Wilder smoothing technique.
+    """
+    delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
+
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+
+
+def calculate_macd(
+    close: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9
+) -> Tuple[pd.Series, pd.Series, pd.Series]:
+    """Return MACD line, signal line and histogram."""
+    fast_ema = calculate_ema(close, span=fast)
+    slow_ema = calculate_ema(close, span=slow)
+    macd_line = fast_ema - slow_ema
+    signal_line = calculate_ema(macd_line, span=signal)
+    histogram = macd_line - signal_line
+    return macd_line, signal_line, histogram

--- a/stock_dashboard/portfolio.py
+++ b/stock_dashboard/portfolio.py
@@ -1,0 +1,211 @@
+"""Lightweight SQLite-backed portfolio tracker used by the dashboard."""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import pandas as pd
+
+from .data import fetch_latest_price
+
+
+@dataclass
+class Trade:
+    """Simple representation of a trade captured through the UI."""
+
+    symbol: str
+    trade_date: date
+    quantity: float
+    price: float
+    side: str
+    fees: float = 0.0
+
+    def normalized_symbol(self) -> str:
+        return self.symbol.strip().upper()
+
+    def normalized_side(self) -> str:
+        return self.side.strip().upper()
+
+
+class PortfolioManager:
+    """Persist and summarise trade history using SQLite."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        default_path = Path(__file__).resolve().parent / "data" / "portfolio.db"
+        self.db_path = Path(db_path) if db_path else default_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # Database helpers
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trades (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol TEXT NOT NULL,
+                    trade_date TEXT NOT NULL,
+                    quantity REAL NOT NULL,
+                    price REAL NOT NULL,
+                    side TEXT NOT NULL,
+                    fees REAL NOT NULL DEFAULT 0
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def add_trade(self, trade: Trade) -> None:
+        """Store a trade in the database."""
+        symbol = trade.normalized_symbol()
+        side = trade.normalized_side()
+
+        if side not in {"BUY", "SELL"}:
+            raise ValueError("Trade side must be either 'BUY' or 'SELL'.")
+        if trade.quantity <= 0:
+            raise ValueError("Quantity must be positive.")
+        if trade.price <= 0:
+            raise ValueError("Price must be positive.")
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO trades(symbol, trade_date, quantity, price, side, fees)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    symbol,
+                    trade.trade_date.isoformat(),
+                    float(trade.quantity),
+                    float(trade.price),
+                    side,
+                    float(trade.fees or 0.0),
+                ),
+            )
+            conn.commit()
+
+    def clear_trades(self) -> None:
+        """Remove all stored trades."""
+        with self._connect() as conn:
+            conn.execute("DELETE FROM trades")
+            conn.commit()
+
+    def get_trades(self) -> pd.DataFrame:
+        """Return the trade ledger as a DataFrame."""
+        with self._connect() as conn:
+            df = pd.read_sql_query(
+                "SELECT symbol, trade_date, quantity, price, side, fees FROM trades ORDER BY trade_date",
+                conn,
+                parse_dates=["trade_date"],
+            )
+        if df.empty:
+            return df
+        df["symbol"] = df["symbol"].str.upper()
+        df["side"] = df["side"].str.upper()
+        return df
+
+    # ------------------------------------------------------------------
+    # Reporting helpers
+    # ------------------------------------------------------------------
+    def _latest_prices(self, symbols: Iterable[str]) -> Dict[str, Optional[float]]:
+        prices: Dict[str, Optional[float]] = {}
+        for symbol in symbols:
+            prices[symbol] = fetch_latest_price(symbol)  # pragma: no cover - network access
+        return prices
+
+    def _summarise_symbol(
+        self, trades: pd.DataFrame, market_price: Optional[float]
+    ) -> Dict[str, float]:
+        trades = trades.sort_values("trade_date")
+        avg_cost = 0.0
+        net_qty = 0.0
+        realized = 0.0
+
+        for _, row in trades.iterrows():
+            qty = float(row["quantity"])
+            price = float(row["price"])
+            fees = float(row.get("fees", 0.0))
+            side = row["side"].upper()
+
+            if side == "BUY":
+                total_cost = avg_cost * net_qty + price * qty + fees
+                net_qty += qty
+                avg_cost = total_cost / net_qty if net_qty else 0.0
+            else:  # SELL
+                if net_qty <= 0:
+                    # No existing position; treat as opening a short with sale price as cost basis.
+                    net_qty -= qty
+                    avg_cost = price
+                    realized -= fees
+                else:
+                    sell_qty = min(qty, net_qty)
+                    realized += (price - avg_cost) * sell_qty - fees
+                    net_qty -= sell_qty
+                    if net_qty == 0:
+                        avg_cost = 0.0
+                    elif qty > sell_qty:
+                        # additional quantity turns the position short
+                        short_qty = qty - sell_qty
+                        net_qty -= short_qty
+                        avg_cost = price
+        market_value = None
+        unrealized = None
+        total_pl = realized
+
+        if market_price is not None:
+            market_value = market_price * net_qty
+            unrealized = (market_price - avg_cost) * net_qty
+            total_pl = realized + (unrealized or 0.0)
+
+        return {
+            "net_quantity": net_qty,
+            "average_cost": avg_cost,
+            "market_price": market_price if market_price is not None else float("nan"),
+            "market_value": market_value if market_value is not None else float("nan"),
+            "realized_pl": realized,
+            "unrealized_pl": unrealized if unrealized is not None else float("nan"),
+            "total_pl": total_pl,
+        }
+
+    def get_portfolio_summary(
+        self, latest_prices: Optional[Dict[str, float]] = None
+    ) -> pd.DataFrame:
+        """Summarise all symbols currently stored in the trade ledger."""
+        trades = self.get_trades()
+        if trades.empty:
+            return pd.DataFrame(
+                columns=[
+                    "symbol",
+                    "net_quantity",
+                    "average_cost",
+                    "market_price",
+                    "market_value",
+                    "realized_pl",
+                    "unrealized_pl",
+                    "total_pl",
+                ]
+            )
+
+        symbols = trades["symbol"].unique()
+        price_lookup = dict(latest_prices or {})
+        missing = [symbol for symbol in symbols if price_lookup.get(symbol) is None]
+        if missing:
+            price_lookup.update(self._latest_prices(missing))
+
+        rows = []
+        for symbol in symbols:
+            metrics = self._summarise_symbol(trades[trades["symbol"] == symbol], price_lookup.get(symbol))
+            rows.append({"symbol": symbol, **metrics})
+
+        summary = pd.DataFrame(rows)
+        return summary


### PR DESCRIPTION
## Summary
- build a Streamlit dashboard that fetches Yahoo Finance data, draws interactive price/indicator charts, and exposes CSV/Excel downloads
- add reusable helpers for indicators, moving-average crossover backtesting, and yfinance data retrieval
- implement an SQLite-backed portfolio tracker, document the workflow for new users, and record dependencies

## Testing
- python -m compileall app.py stock_dashboard

------
https://chatgpt.com/codex/tasks/task_e_68c9cb7c316c832a8144f8a1ba67237d